### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,52 @@
 
 > publish any directory to the web with a single command
 
-### Rationale
+## Rationale
 
-The web promised us shipping web projects would be fast, easy, and low risk. Surge delivers on that promise by making rapid deployment of front-end projects impossible to fuck up. To publish a web project run `surge` within any directory and that directory becomes live on the web at that very moment. Both account and app creation is implicit, so there is no setup or registration. Simply install surge and start tossing projects in the wild without a second thought.
+The web promised us shipping web projects would be fast, easy, and low risk. Surge delivers on that promise by making rapid deployment of front-end projects impossible to fuck up. To publish a web project run `surge` within any directory and that directory becomes live on the web at that very moment.
 
-### Features
+Both account and app creation is implicit, so there is no setup or registration. Simply install surge and start tossing projects in the wild without a second thought.
+
+## Features
 
 - Single command deployment.
 - Free production grade static hosting
 - Free CNAME support.
 - Free SSL support.
-- Fallback 404.html pages.
-- Catch all 200.html pages.
+- Custom 404.html pages.
+- HTML5 mode 200.html pages.
 
-### Install
+## Install
 
     npm install -g surge
 
-### Usage
+## Usage
 
     surge <dir> [--domain=<example.com>]
 
-### Examples
+## Examples
 
-Publish current working directory.
+The following examples show how you can publish any directory to the web with Surge.
+
+### Publish current working directory.
 
     surge
 
-If you are using tools like Grunt and Gulp and you have a compile directory. From within the root of your project pass in the path to your output direcotory to only upload your compiled assets. (note - you may want to also `.gitignore` that direcory in order to keep compiled assets out of your repo.
+If you’re using tools like Grunt, Gulp, or a static site generator like Jekyll, your files are output into a compile directory like `_site/`, `build/`, or `www/`. From the root of your project, pass Surge the path to this directory to upload your compiled assets.
 
     surge www
 
-If wanting a particular subdomain just pass in as an optional arg
+You may also add this directory to your `.gitignore` to keep your compiled assets out of your Git history.
 
-    surge --domain foo.sarge.sh
+### Publish with a custom subdomain
+
+If no subdomain is specified, Surge will take care if this for you. If you’d like to specify one yourself, just pass it in as an optional argument:
+
+    surge --domain foo.surge.sh
+
+Now, if it’s available, `foo` will be used as the subdomain.
 
 As an alternative you may pass surge a data stream.
 
     echo "<h1>Hello World</h1>" | surge
-
-
 


### PR DESCRIPTION
- Changes heading levels, adds headings for examples
- Breaks up rationale into two paragraphs
- Changes _Catch-all_ to [_HTML5 mode_, which is Angular’s term](https://docs.angularjs.org/guide/$location) for Push State / History API that the
  200.html file helps with
- Clarify you 404.html pages are custom
- Mentions SSGs and expands on first example
- Corrects `sarge.sh` to `surge.sh`
