### PR TITLE
Adds support for showing the version number in the CLI

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,5 +1,6 @@
 module.exports = [
   require("./pkg"),
+  require("./version"),
   require("./help"),
   require("./shorthand"),
   require("./project"),

--- a/lib/middleware/version.js
+++ b/lib/middleware/version.js
@@ -1,0 +1,9 @@
+var pkg = require("../../package.json")
+
+module.exports = function(req, next){
+  if (req.argv.version || req.argv.V) {
+    console.log(pkg.version)
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
`-V` or `--version` will now return the value from the `package.json`.

The only thing that I was unsure about was if I was correct in requiring the `package.json`, or if I should have required the `pkg.js` module.
