### PR TITLE
Adds a friendly goodbye instead of erroring

### DIFF
--- a/lib/middleware/deploy.js
+++ b/lib/middleware/deploy.js
@@ -7,26 +7,16 @@ var tar  = require('tar')
 var zlib = require('zlib')
 var fsReader  = require('fstream-ignore')
 var surge    = require('../surge')
+var ProgressBar = require("progress")
 
 
 
 module.exports = function(req, next){
-  //var bar = new ProgressBar('             upload: [:bar] :percent :etas', { total: 20, incomplete: ' ' });
-
-  // var timer = setInterval(function () {
-  //   bar.tick();
-  //   if (bar.complete) {
-  //     console.log('\ncomplete\n');
-  //     clearInterval(timer);
-  //   }
-  // }, 100);
-
-  // var upload = request.put("http://" + req.argv.endpoint + "/" + req.domain)
-  //   .auth("token", req.creds.token, true)
-
 
   headers = {
-    "version" : req.pkg.version
+    "version" : req.pkg.version,
+    "file-count": req.fileCount,
+    "project-size": req.projectSize
   }
 
   if (req.argv.a)
@@ -41,24 +31,32 @@ module.exports = function(req, next){
     uri: "http://" + req.argv.endpoint + "/" + req.domain
   }).auth("token", req.creds.token, true)
 
-  process.stdout.write("             upload: ".grey)
+  //process.stdout.write("             upload: ".grey)
+  //var multi = multimeter(process)
+
+
+
+  var progressBar = new ProgressBar('             upload:'.grey + ' [:bar] :percent :etas', {
+    complete: '=',
+    incomplete: ' ',
+    width: 26,
+    total: req.projectSize
+  })
 
   upload.on('response', function(rsp){
-    if (rsp.statusCode == 200) {
 
+    if (rsp.statusCode == 200) {
       rsp.on('data', function(chunk){
-        process.stdout.write(".".grey)
-        //bar.tick();
-        //helpers.log(chunk.toString().grey)
+        progressBar.tick(1)
       })
 
       rsp.on('end', function(stuff) {
-        //bar.tick(100);
-        helpers.log(" done")
-        helpers.log("         ip address:".grey, "192.241.214.148")
-        helpers.log()
+        console.log()
+        console.log()
         next()
       })
+
+
 
     } else if (rsp.statusCode == 403) {
       helpers.log()

--- a/lib/middleware/project.js
+++ b/lib/middleware/project.js
@@ -8,6 +8,10 @@ module.exports = function(req, next){
   req.project = path.resolve(project || "")
 
   var p = function(){
+    process.on('uncaughtException', function (err) {
+      helpers.log('\n       @getSurge:'.grey, '   See you next time!\n');
+    });
+
     helpers.prompt.get({
       name: "project",
       description: "       project path:",
@@ -46,7 +50,6 @@ module.exports = function(req, next){
   } else {
     p()
   }
-
 
 
 }

--- a/lib/middleware/project.js
+++ b/lib/middleware/project.js
@@ -8,9 +8,6 @@ module.exports = function(req, next){
   req.project = path.resolve(project || "")
 
   var p = function(){
-    process.on('uncaughtException', function (err) {
-      helpers.log('\n       @getSurge:'.grey, '   See you next time!\n');
-    });
 
     helpers.prompt.get({
       name: "project",

--- a/lib/middleware/size.js
+++ b/lib/middleware/size.js
@@ -19,18 +19,18 @@ module.exports = function(req, next){
   //process.stdout.write("               size:".grey, "checking...")
   process.stdout.write("               size: ".grey)
 
-  var total = 0;
-  var fileCount = 0
+  req.projectSize = 0;
+  req.fileCount = 0
   var project = fsReader({ 'path': req.project, ignoreFiles: [".surgeignore"] })
   project.addIgnoreRules([".git"])
 
   project.on("child", function (c) {
     fs.lstat(c.path, function(err, stats) {
-      total += stats.size
-      if (!stats.isDirectory()) fileCount++
+      req.projectSize += stats.size
+      if (!stats.isDirectory()) req.fileCount++
     })
   }).on("close", function(){
-    helpers.log(fileCount + " files,", humanFileSize(total))
+    helpers.log(req.fileCount + " files,", humanFileSize(req.projectSize))
     next()
   })
 

--- a/lib/middleware/util/helpers.js
+++ b/lib/middleware/util/helpers.js
@@ -16,3 +16,15 @@ prompt.message = sig
 prompt.delimiter = ""
 
 exports.prompt = prompt
+
+process.on('uncaughtException', function(err) {
+  exports.log('\n          @getSurge:'.grey, 'See you next time!\n')
+  // if (req.argv.v)
+  //   exports.log(e.stack)
+  process.exit(99);
+});
+
+process.on('SIGINT', function(err) {
+  exports.log('\n          @getSurge:'.grey, 'See you next time!\n\n')
+  process.exit(99);
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "fstream-ignore": "1.0.1",
     "moniker": "^0.1.2",
     "netrc": "0.1.3",
+    "progress": "^1.1.8",
     "prompt": "0.2.13",
     "request": "2.40.0",
     "tar": "1.0.0",


### PR DESCRIPTION
There’s probably a better spot to put this, but I thought Surge should exit quietly if you changed your mind about a deployment instead of giving an error:

```sh
TypeError: Cannot read property 'project' of undefined
    at /Users/kennethormandy/Sites/kennethormandy/surge/lib/middleware/project.js:24:15
    at /Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/lib/prompt.js:316:20
    at /Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/node_modules/utile/node_modules/async/lib/async.js:136:21
    at assembler (/Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/lib/prompt.js:282:18)
    at /Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/lib/prompt.js:322:20
    at /Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/lib/prompt.js:510:14
    at onError (/Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/node_modules/read/lib/read.js:94:12)
    at Interface.<anonymous> (/Users/kennethormandy/Sites/kennethormandy/surge/node_modules/prompt/node_modules/read/lib/read.js:66:5)
    at Interface.EventEmitter.emit (events.js:92:17)
    at Interface._ttyWrite
```

Then, I realised we could say a friendly goodbye instead. This is just an example for now, but later we could do some cool stuff with it, ex. random messages, last Tweet…I dunno.

To try it out:

```sh
./lib/cli.js
# Now press ctrl+c
```