### PR TITLE
Adds basic support for CNAME files

### DIFF
--- a/lib/middleware/domain.js
+++ b/lib/middleware/domain.js
@@ -11,8 +11,7 @@ module.exports = function(req, next){
       domain(req.argv.domain + ".surge.sh", next)
     } else {
       req.domain = req.argv.domain
-      helpers.log("             domain:".grey, req.domain)
-      return next()
+      domain(req.domain, next)
     }
   } else if (fs.existsSync(path.join(req.project, "CNAME"))) {
     fs.readFile(path.join(req.project, "CNAME"), "utf8", function(err, cname) {


### PR DESCRIPTION
## Basic CNAME support

If you haven’t passed in a domain on the CLI, Surge will pre-fill one from a CNAME file in the project root before suggesting a new one.

To test:

```
echo "example.com" > CNAME
./lib/cli.js
```
### Caveats
- Will only be deployed to the first domain
  listed in the CNAME file. Once/if multiple domains are supported on the CLI, this can be change.
- Doesn’t assume it’s a Surge subdomain (ex. If you list `example`, it
  will try and deploy to `example`, not `example.surge.sh`. I don’t think
  this is a good thing, but didn’t add it yet since it probably requires more eloquently written code to avoid being redundant.)
