### PR TITLE
Fixes “missing repo” warning on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.3",
   "description": "the `npm` of web publishing",
   "main": "./lib/surge.js",
+  "repository": "https://github.com/sintaxi/surge",
   "scripts": {
     "test": "mocha test"
   },


### PR DESCRIPTION
Gets rid of this:

![screen shot 2014-11-21 at 11 56 56](https://cloud.githubusercontent.com/assets/1581276/5148613/842c57c6-7175-11e4-9569-17cb4a78cd98.png)
