### PR TITLE
Improves #32, adds version flag to help

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Run `surge --help` to see the following overview of the `surge` command...
     -d, --domain        domain of your project (<random>.surge.sh)
     -e, --endpoint      domain of API server (surge.sh)
     -v, --verbose       verbose output
+    -V, --version       show the version number
     -h, --help          show this help message
 
   Shorthand usage:
@@ -41,4 +42,3 @@ If you’re using tools like Grunt, Gulp, or a static site generator like Jekyll
     surge www
 
 You may also add this directory to your `.gitignore` to keep your compiled assets out of your Git history.
-

--- a/lib/middleware/help.js
+++ b/lib/middleware/help.js
@@ -1,21 +1,22 @@
-
+var helpers = require("./util/helpers")
 
 module.exports = function(req, next){
   if (req.argv.help || req.argv.h) {
-    console.log("  Usage:")
-    console.log("    surge [options]")
-    console.log()
-    console.log("  Options: ")
-    console.log("    -p, --project       path to projects asset directory (./)")
-    console.log("    -d, --domain        domain of your project (<random>.surge.sh)")
-    console.log("    -e, --endpoint      domain of API server (surge.sh)")
-    console.log("    -a, --add           add collaborator via email address")
-    console.log("    -r, --rem           remove collaborator via email address")
-    console.log("    -v, --verbose       verbose output")
-    console.log("    -h, --help          show this help message")
-    console.log()
-    console.log("  Shorthand usage:")
-    console.log("    surge [project] [domain]")
+    helpers.log("  Usage:")
+    helpers.log("    surge [options]")
+    helpers.log()
+    helpers.log("  Options: ")
+    helpers.log("    -p, --project       path to projects asset directory (./)")
+    helpers.log("    -d, --domain        domain of your project (<random>.surge.sh)")
+    helpers.log("    -e, --endpoint      domain of API server (surge.sh)")
+    helpers.log("    -a, --add           add collaborator via email address")
+    helpers.log("    -r, --rem           remove collaborator via email address")
+    helpers.log("    -v, --verbose       verbose output")
+    helpers.log("    -V, --version       show the version number")
+    helpers.log("    -h, --help          show this help message")
+    helpers.log()
+    helpers.log("  Shorthand usage:")
+    helpers.log("    surge [project] [domain]")
   } else {
     next()
   }


### PR DESCRIPTION
Help now includes:

``` sh
    -V, --version       show the version number
```

Also changes `console.log()` to the `console.log()` helper.
