### PR TITLE
Adds explicit reference to bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.2",
   "description": "the `npm` of web publishing",
   "main": "./lib/surge.js",
+  "bin": "./lib/cli.js",
   "repository": "https://github.com/sintaxi/surge",
   "scripts": {
     "test": "mocha test"


### PR DESCRIPTION
This references `cli.js` as the bin in the `package.json.`

I’m not sure if this is technically correct, but I had to do some trickery to be able to `require` Surge in grunt-surge, and was curious if this would fix it.