### PR TITLE
Adds notification when there’s a new release available

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -20,6 +20,7 @@ module.exports = [
   require("./domain"),
   require("./protocol"),
   require("./deploy"),
-  require("./ipaddress")
+  require("./ipaddress"),
+  require("./notify")
   //require("./log")
 ]

--- a/lib/middleware/notify.js
+++ b/lib/middleware/notify.js
@@ -1,0 +1,24 @@
+var updateNotifier = require("update-notifier");
+var helpers        = require("./util/helpers");
+var pkg            = require(__dirname + "./../../package.json");
+
+module.exports = function(req, next){
+  // Checks for available update and returns an instance
+  var notifier = updateNotifier({
+    // updateCheckInterval: 1000, // For testing
+    pkg: pkg
+  });
+
+  helpers
+    .log("                    ┌────────────────────────────────────────┐ ".grey)
+    .log("                    │  ".grey + "A new version of " + "Surge".bold + " is available!" + "  │".grey)
+    .log("                    │  ".grey + "Yours:  ".grey + "v" + notifier.update.current + "                        │".grey)
+    .log("                    │  ".grey + "Latest: ".grey + "v" + notifier.update.latest + "        ack               │".grey)
+    .log("                    │                                        │".grey)
+    .log("                    │  ".grey + "Run " + "npm install -g ".green + notifier.update.name.green + " to update." + "   │".grey)
+    .log("                    └────────────────────────────────────────┘ ".grey)
+    .log()
+    .log()
+
+  next();
+}

--- a/package.json
+++ b/package.json
@@ -7,31 +7,30 @@
   "dependencies": {
     "du": "0.1.0",
     "fstream-ignore": "1.0.2",
+    "minimist": "1.1.1",
     "moniker": "0.1.2",
     "netrc": "0.1.3",
-    "prompt": "~0.2.14",
+    "opn": "1.0.1",
     "progress": "1.1.8",
+    "prompt": "~0.2.14",
+    "read": "1.0.5",
     "request": "2.40.0",
     "split": "0.3.1",
     "surge-ignore": "0.2.0",
     "tar": "1.0.0",
     "tar.gz": "0.1.1",
-    "url-parse-as-address": "1.0.0",
-    "read": "1.0.5",
-    "minimist": "1.1.1",
-    "opn": "1.0.1"
+    "url-parse-as-address": "1.0.0"
   },
   "devDependencies": {
     "mocha": "*"
   },
   "license": "ISC",
   "main": "./lib/surge.js",
-  "repository": "sintaxi/surge",
-  "scripts": {
-    "test": "mocha test"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/sintaxi/surge.git"
+  },
+  "scripts": {
+    "test": "mocha test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "surge-ignore": "0.2.0",
     "tar": "1.0.0",
     "tar.gz": "0.1.1",
+    "update-notifier": "^0.4.0",
     "url-parse-as-address": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
![screenshot 2015-05-07 10 32 59](https://cloud.githubusercontent.com/assets/1581276/7521774/538f8c1a-f4a5-11e4-9982-4d8081a19c18.png)

Let people know when there’s a new release of Surge available using [update-notifier](https://github.com/yeoman/update-notifier). The default timing settings are left in place, so you’d only see a notification at most once each day you use Surge, and never until after you’d completed a deploy.

![pr](https://cloud.githubusercontent.com/assets/1581276/7521769/4c91a808-f4a5-11e4-9e0f-ae7854912ace.gif)
