### PR TITLE
Fixes #84

### DIFF
--- a/lib/middleware/prep.js
+++ b/lib/middleware/prep.js
@@ -3,12 +3,13 @@ var path = require("path")
 var tar  = require('tar')
 var zlib = require('zlib')
 var fsReader  = require('fstream-ignore')
+var ignore = require("surge-ignore")
 
 module.exports = function(req, next){
   var pack = tar.Pack()
   var zip = zlib.Gzip()
   var project = fsReader({ 'path': req.project, ignoreFiles: [".surgeignore"] })
-  project.addIgnoreRules([".git"])
+  project.addIgnoreRules(ignore)
 
   req.tarballPath = path.resolve("/tmp/", Math.random().toString().split(".")[1] + ".tar")
 

--- a/lib/middleware/size.js
+++ b/lib/middleware/size.js
@@ -2,6 +2,7 @@ var du        = require("du")
 var helpers   = require("./util/helpers")
 var fsReader  = require('fstream-ignore')
 var fs        = require("fs")
+var ignore    = require("surge-ignore")
 
 function humanFileSize(bytes, si) {
     var thresh = si ? 1000 : 1024;
@@ -22,7 +23,7 @@ module.exports = function(req, next){
   req.projectSize = 0;
   req.fileCount = 0
   var project = fsReader({ 'path': req.project, ignoreFiles: [".surgeignore"] })
-  project.addIgnoreRules([".git"])
+  project.addIgnoreRules(ignore)
 
   project.on("child", function (c) {
     fs.lstat(c.path, function(err, stats) {


### PR DESCRIPTION
This PR lets Surge factor in [our ignore rules](https://github.com/chloi/surge-ignore) when evaluating the app filesize.

![pr](https://cloud.githubusercontent.com/assets/1581276/7603528/d26e8548-f8e9-11e4-9cdc-e58c06f8b537.gif)

The app in this gif has two files, plus `node_modules/` and `bower_components/` files. Read as 47 files first with Surge, correctly read as 2 files with the PR.

Modularity is cool. :package: