### PR TITLE
Adds domain validation before upload or teardown

### DIFF
--- a/lib/middleware/domain.js
+++ b/lib/middleware/domain.js
@@ -3,6 +3,7 @@ var moniker = require("moniker")
 var fs = require("fs")
 var path = require("path")
 var os = require("os")
+var isDomain = require("is-domain")
 
 module.exports = function(req, next, abort){
   var label = "             domain:".grey
@@ -11,7 +12,7 @@ module.exports = function(req, next, abort){
     req.domain = req.argv.domain || fs.readFileSync(path.join(req.project, "CNAME")).toString()
     req.domain = req.domain.split(os.EOL)[0].trim()
 
-    if (req.domain.split(".").length === 1) {
+    if (isDomain(req.domain) !== true) {
       return getDomain(req.domain, next)
     } else {
       console.log(label, req.domain)
@@ -28,8 +29,8 @@ module.exports = function(req, next, abort){
       default: suggestion,
       edit: true,
     }, function(err, domain){
-      if (domain === undefined) return abort()
-      if (domain.length < 2 || domain.split(".").length < 2) return getDomain(domain)
+      if (domain === undefined) return abort("Please try again with a valid domain name.")
+      if (isDomain(domain) !== true) return getDomain(domain)
       req.domain = domain
       return next()
     })

--- a/lib/middleware/teardown.js
+++ b/lib/middleware/teardown.js
@@ -5,6 +5,7 @@ var helpers     = require("./util/helpers")
 var path        = require("path")
 var fs          = require("fs")
 var os          = require("os")
+var isDomain    = require("is-domain")
 
 module.exports = function(req, next, abort){
   if (req.argv["_"][0] !== "teardown") {
@@ -52,8 +53,8 @@ module.exports = function(req, next, abort){
         default: suggestion,
         edit: true,
       }, function(err, domain, isDefault){
-        if (domain === undefined) return abort()
-        if (err || domain.length < 1 || domain.split(".").length < 2) return getDomain(domain)
+        if (domain === undefined) return abort("Unable to remove, please use a valid domain name.")
+        if (err || isDomain(domain) !== true) return getDomain(domain)
         return remove(domain)
       })
     }
@@ -61,7 +62,7 @@ module.exports = function(req, next, abort){
     var domain = req.argv.domain || req.argv["_"][1]
 
     if (domain) {
-      if (domain.split(".").length === 1) {
+      if (isDomain(domain) !== true) {
         return getDomain()
       } else {
         helpers.log(label, domain)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "du": "0.1.0",
     "fstream-ignore": "1.0.2",
+    "is-domain": "0.0.1",
     "moniker": "0.1.2",
     "netrc": "0.1.3",
     "prompt": "~0.2.14",


### PR DESCRIPTION
Fixes #23.

- Checks for a valid domain before starting an upload or teardown
- Works with a `CNAME` file, `--domain` or the domain input

![out](https://cloud.githubusercontent.com/assets/1581276/7891582/ae7463d0-0602-11e5-8d81-735f1c4cf8bb.gif)