### PR TITLE
Improves domain validation consistency

### DIFF
--- a/lib/middleware/domain.js
+++ b/lib/middleware/domain.js
@@ -3,7 +3,6 @@ var moniker = require("moniker")
 var fs = require("fs")
 var path = require("path")
 var os = require("os")
-var isDomain = require("is-domain")
 
 module.exports = function(req, next, abort){
   var label = "             domain:".grey
@@ -12,7 +11,7 @@ module.exports = function(req, next, abort){
     req.domain = req.argv.domain || fs.readFileSync(path.join(req.project, "CNAME")).toString()
     req.domain = req.domain.split(os.EOL)[0].trim()
 
-    if (isDomain(req.domain) !== true) {
+    if (!helpers.validDomain(req.domain)) {
       return getDomain(req.domain, next)
     } else {
       console.log(label, req.domain)
@@ -30,10 +29,17 @@ module.exports = function(req, next, abort){
       edit: true,
     }, function(err, domain){
       if (domain === undefined) return abort("Please try again with a valid domain name.")
-      if (isDomain(domain) !== true) return getDomain(domain)
+      if (err || !helpers.validDomain(domain)) {
+        console.log("                    ", "Please enter valid domain name…".grey)
+        return getDomain(domain)
+      }
       req.domain = domain
       return next()
     })
+  }
+
+  function validDomain(domain) {
+
   }
 
   getDomain()

--- a/lib/middleware/ssl.js
+++ b/lib/middleware/ssl.js
@@ -5,6 +5,7 @@ var path        = require("path")
 var fs          = require("fs")
 var os          = require("os")
 var split       = require("split")
+var parseUrl    = require("url-parse-as-address")
 
 module.exports = function(req, next, abort){
   if (req.argv["_"][0] !== "ssl") {
@@ -155,23 +156,27 @@ module.exports = function(req, next, abort){
           edit: true,
         }, function(err, domain, isDefault){
           if (domain === undefined) return abort("no domain provided")
-          if (domain === "") return getDomain()
-          if (err || domain.length < 1 || domain.split(".").length < 2) return getDomain(domain)
-          req.domain = domain
+          if (domain === "") {
+            console.log("                    ", "Please enter the domain you’d like to add SSL to".grey)
+            return getDomain()
+          }
+          if (err || !helpers.validDomain(domain)) {
+            console.log("                    ", "Please enter valid domain name…".grey)
+            return getDomain(domain)
+          }
+          req.domain = parseUrl(domain).host // #110
           return mPem(req, next, abort)
         })
       }
 
       var domain = req.argv["domain"] || req.argv["d"]
 
-      if (domain) {
-        if (domain.split(".").length > 1) {
-          req.domain = domain
-          console.log(label, domain)
-          return mPem(req, next, abort)
-        } else {
-          return getDomain(domain)
-        }
+      if (validDomain(domain)) {
+        req.domain = parseUrl(domain).host
+        console.log(label, domain)
+        return mPem(req, next, abort)
+      } else {
+        return getDomain(domain)
       }
 
       try {

--- a/lib/middleware/teardown.js
+++ b/lib/middleware/teardown.js
@@ -5,7 +5,6 @@ var helpers     = require("./util/helpers")
 var path        = require("path")
 var fs          = require("fs")
 var os          = require("os")
-var isDomain    = require("is-domain")
 
 module.exports = function(req, next, abort){
   if (req.argv["_"][0] !== "teardown") {
@@ -54,7 +53,10 @@ module.exports = function(req, next, abort){
         edit: true,
       }, function(err, domain, isDefault){
         if (domain === undefined) return abort("Unable to remove, please use a valid domain name.")
-        if (err || isDomain(domain) !== true) return getDomain(domain)
+        if (err || !validDomain(domain)) {
+          console.log()
+          return getDomain(domain)
+        }
         return remove(domain)
       })
     }
@@ -62,7 +64,7 @@ module.exports = function(req, next, abort){
     var domain = req.argv.domain || req.argv["_"][1]
 
     if (domain) {
-      if (isDomain(domain) !== true) {
+      if (validDomain(domain)) {
         return getDomain()
       } else {
         helpers.log(label, domain)

--- a/lib/middleware/util/helpers.js
+++ b/lib/middleware/util/helpers.js
@@ -6,6 +6,7 @@ var os          = require('os')
 var url         = require("url")
 var urlAddy     = require("url-parse-as-address")
 var read = require("read")
+var isDomain = require("is-domain")
 
 
 var sig = '[' + 'surge'.cyan + ']'
@@ -184,4 +185,12 @@ exports.payment = function(req, stripe_pk, existing){
     }
   }
 
+}
+
+exports.validDomain = function(domain) {
+  if (isDomain(domain) === true || isDomain(urlAddy(domain).host) === true) {
+    return true
+  } else {
+    return false
+  }
 }


### PR DESCRIPTION
This PR fixes [Force HTTPS](https://surge.sh/help/using-https-by-default) when your domain is in a `CNAME` file, which is currently broken in Surge v0.13.0:
![out](https://cloud.githubusercontent.com/assets/1581276/8016785/2a581d44-0b9d-11e5-991b-996c5676e47c.gif)

It also improves domain validation consistency by moving some of it to `helpers.js`, and adds a validation message so you have some feedback about what is wrong:
![out](https://cloud.githubusercontent.com/assets/1581276/8016752/96c18e4e-0b9c-11e5-879f-69da08f7009d.gif)

I tested this pretty well, but admittedly I probably should have done it as two separate PRs. It would be nice if you don’t mind testing it a little before merging it.

Also works on Windows, as long as you didn’t create the CNAME file using `echo` per #70. 