### PR TITLE
Fixes SSL command domain validation

### DIFF
--- a/lib/middleware/ssl.js
+++ b/lib/middleware/ssl.js
@@ -171,7 +171,7 @@ module.exports = function(req, next, abort){
 
       var domain = req.argv["domain"] || req.argv["d"]
 
-      if (validDomain(domain)) {
+      if (helpers.validDomain(domain)) {
         req.domain = parseUrl(domain).host
         console.log(label, domain)
         return mPem(req, next, abort)

--- a/lib/middleware/ssl.js
+++ b/lib/middleware/ssl.js
@@ -176,16 +176,17 @@ module.exports = function(req, next, abort){
         console.log(label, domain)
         return mPem(req, next, abort)
       } else {
-        return getDomain(domain)
+        try {
+          domain = fs.readFileSync(path.join(process.cwd(), "CNAME")).toString()
+          domain = domain.split(os.EOL)[0].trim()
+          return getDomain(domain)
+        } catch(e) {
+          return getDomain()
+        }
+        //
+        // return getDomain(domain)
       }
 
-      try {
-        domain = fs.readFileSync(path.join(process.cwd(), "CNAME")).toString()
-        domain = domain.split(os.EOL)[0].trim()
-        return getDomain(domain)
-      } catch(e) {
-        return getDomain()
-      }
     }
 
     return mDomain(req, next, abort)

--- a/lib/middleware/util/helpers.js
+++ b/lib/middleware/util/helpers.js
@@ -188,7 +188,7 @@ exports.payment = function(req, stripe_pk, existing){
 }
 
 exports.validDomain = function(domain) {
-  if (isDomain(domain) === true || isDomain(urlAddy(domain).host) === true) {
+  if (domain && (isDomain(domain) === true || isDomain(urlAddy(domain).host) === true)) {
     return true
   } else {
     return false


### PR DESCRIPTION
This fixes the SSL command which I broke in v0.14.0 with a typo :disappointed:
It also restores the `CNAME` file support for the SSL command

Tested on OS X with Node v0.10.36 and Windows 7 with Node v0.12.4