### PR TITLE
Fixes protocol, CNAME for teardown (related to #110)

### DIFF
--- a/lib/middleware/teardown.js
+++ b/lib/middleware/teardown.js
@@ -5,6 +5,7 @@ var helpers     = require("./util/helpers")
 var path        = require("path")
 var fs          = require("fs")
 var os          = require("os")
+var parseUrl    = require("url-parse-as-address")
 
 module.exports = function(req, next, abort){
   if (req.argv["_"][0] !== "teardown") {
@@ -53,28 +54,24 @@ module.exports = function(req, next, abort){
         edit: true,
       }, function(err, domain, isDefault){
         if (domain === undefined) return abort("Unable to remove, please use a valid domain name.")
-        if (err || !validDomain(domain)) {
-          console.log()
+        if (err || !helpers.validDomain(domain)) {
+          helpers.log("                    ", "Please enter valid domain name…".grey)
           return getDomain(domain)
         }
-        return remove(domain)
+        return remove(parseUrl(domain).host) // #110
       })
     }
 
     var domain = req.argv.domain || req.argv["_"][1]
 
-    if (domain) {
-      if (validDomain(domain)) {
-        return getDomain()
-      } else {
-        helpers.log(label, domain)
-        return remove(domain)
-      }
+    if (helpers.validDomain(domain)) {
+      helpers.log(label, domain) // Display without protocol
+      return remove(parseUrl(domain).host) // #110
     } else {
       try {
         domain = fs.readFileSync(path.join(process.cwd(), "CNAME")).toString()
         domain = domain.split(os.EOL)[0].trim()
-        getDomain()
+        getDomain(domain)
       } catch(e) {
         getDomain()
       }


### PR DESCRIPTION
Tested on Windows with Node v0.12.4 and OS X with Node v0.10.36. This could probably be a patch release.

Basically the same PR as https://github.com/sintaxi/surge/pull/115 but also for `teardown`.