### PR TITLE
Catch a JSON parse error on data and ignore it

### DIFF
--- a/lib/middleware/deploy.js
+++ b/lib/middleware/deploy.js
@@ -74,7 +74,12 @@ module.exports = function(req, next){
 
     //try {
 
-      var payload  = JSON.parse(tick.toString())
+      try {
+        var payload  = JSON.parse(tick.toString())
+      } catch(e) {
+        return;
+      }
+
 
       if (payload.hasOwnProperty("type") && payload.type === "error") {
         console.log()


### PR DESCRIPTION
Fixes #113 by wrapping the `JSON.parse(...)` in a try catch and just returning when there is an error. I was getting this error regularly running:

|Software |Version|
|-------------|----------|
|os      | OSX 10.10.3| 
| surge | 0.14.2      |
| node | 0.12.5    |