### PR TITLE
Adds work-in-progress Windows fiexs

### DIFF
--- a/lib/middleware/creds.js
+++ b/lib/middleware/creds.js
@@ -1,6 +1,6 @@
 var path        = require("path")
 var fs          = require("fs")
-var netrc       = require("netrc")
+var netrc       = require("@surge/netrc")
 var localCreds  = require("./util/creds.js")
 var helpers     = require("./util/helpers.js")
 

--- a/lib/middleware/login.js
+++ b/lib/middleware/login.js
@@ -3,14 +3,12 @@ var helpers = require("./util/helpers")
 
 module.exports = function(req, next){
   if (req.argv.hasOwnProperty("_") && (req.argv["_"]["0"] === "login" || req.argv["_"]["0"] === "token")) {
-    var filePath = path.join(process.env[(/^win/.test(process.platform)) ? 'USERPROFILE' : 'HOME'], ".netrc")
     if (req.argv["_"]["0"] === "login") {
       helpers.log()
       helpers.log("    Logged in as " + req.creds.email.green + ".")
     } else if(req.argv["_"]["0"] === "token") {
       helpers.log("              token: ".grey + req.creds.token)
     }
-    //helpers.log("Your access token stored in " + filePath.grey + " file")
     helpers.log()
     process.exit()
   } else {

--- a/lib/middleware/util/creds.js
+++ b/lib/middleware/util/creds.js
@@ -1,6 +1,6 @@
 var path        = require("path")
 var fs          = require("fs")
-var netrc       = require("netrc")
+var netrc       = require("@surge/netrc")
 var os          = require("os")
 var url         = require("url")
 var address     = require("url-parse-as-address")
@@ -39,7 +39,7 @@ module.exports = function(endpoint){
     }
   }
 
-  var set = function(email, token){
+  var set = function(email, token) {
     var home = process.env[(/^win/.test(process.platform)) ? 'USERPROFILE' : 'HOME'];
     var file = path.join(home, ".netrc")
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fstream-ignore": "1.0.2",
     "is-domain": "0.0.1",
     "moniker": "0.1.2",
-    "@surge/netrc": "0.1.5-beta.4",
+    "@surge/netrc": "0.1.5-beta.5",
     "prompt": "~0.2.14",
     "progress": "1.1.8",
     "request": "2.40.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fstream-ignore": "1.0.2",
     "is-domain": "0.0.1",
     "moniker": "0.1.2",
-    "netrc": "0.1.3",
+    "@surge/netrc": "0.1.5-beta.4",
     "prompt": "~0.2.14",
     "progress": "1.1.8",
     "request": "2.40.0",


### PR DESCRIPTION
**Don’t merge yet**

This adds a [slightly modified version] of the netrc package, which will hopefully fix or improve the Windows login issue #93.

If we could release this as [a dist-tag on npm](https://docs.npmjs.com/cli/dist-tag), I think that would be really helpful. Then, someone on Windows could:

```
npm install -g surge@next
```

…or whatever, and essentially get a pre-release version. This is now npm is doing their own betas. You can `npm install -g npm@next` and get the next stable version before it is moved to `@latest`.

Let me know what you think!