### PR TITLE
Fix Windows authorization

### DIFF
--- a/lib/middleware/util/creds.js
+++ b/lib/middleware/util/creds.js
@@ -8,10 +8,15 @@ var address     = require("url-parse-as-address")
 module.exports = function(endpoint){
   var endpoint = address.parse(endpoint)
   var host = endpoint.host
+  
+  var getFile = function() {
+    var home = process.env[(/^win/.test(process.platform)) ? 'USERPROFILE' : 'HOME']
+    return path.join(home, ".netrc")
+  }
 
   var get = function(){
     try {
-      var obj = netrc()
+      var obj = netrc(getFile())
     }catch(e){
       var obj = {}
     }
@@ -40,11 +45,10 @@ module.exports = function(endpoint){
   }
 
   var set = function(email, token){
-    var home = process.env[(/^win/.test(process.platform)) ? 'USERPROFILE' : 'HOME'];
-    var file = path.join(home, ".netrc")
+    var file = getFile();
 
     try {
-      var obj = netrc()
+      var obj = netrc(file)
     }catch(e){
       var obj = {}
     }


### PR DESCRIPTION
The netrc library doesn't determine a Windows user's home path properly (as noted in camshaft/netrc#7) but surge does so I've updated the code that calls `netrc()` to also pass in the .netrc file path: `netrc(file)`.

This fixes the issue with Windows login but even if it wasn't an issue I still think it's a better idea to pass in the file path rather than allow netrc to possibly determine a path that doesn't exactly match the one that surge writes to.