### PR TITLE
Adds npm debug files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.swp
+*.log*


### PR DESCRIPTION
So I don’t accidentally commit `npm-debug.log` files! :octocat: :no_entry_sign: 