### PR TITLE
Fixes parser for Yargs

### DIFF
--- a/lib/surge.js
+++ b/lib/surge.js
@@ -39,6 +39,8 @@ var space = function(req, next){ console.log(); next() }
 var parse = function(arg){
   if(arg.hasOwnProperty("parent") && arg.parent.hasOwnProperty("rawArgs")){
     arg = arg.parent.rawArgs.slice(3)
+  } else if (arg.argv && arg.argv._) {
+    arg = arg.argv._
   }
   return arg instanceof Array
     ? minimist(arg)


### PR DESCRIPTION
I needed to add this before I could use build Surge into a CLI using Yargs. I believe this is because you can require Yargs in one of two ways:

```js
var surge = require('surge')()
var argv = require('yargs').argv
var hooks = {}

if (argv._[0] === 'login') {
  console.log('Ran the `login` command')
}
```

Or the way I think you’d want to do things with Surge:

```js
var surge = require('surge')()
var yargs = require('yargs')
var hooks = {}

yargs
  .command('login', 'Login to your account.', surge.login(hooks))
  .argv
```

…but without this change, in the second example, the entire `yargs` object is passed to Surge rather than just `yargs._.argv`, so this change in the parser fixes that.

***

This is probably obvious, but I am kind of out of my depth here, so feel free to critique accordingly. I only have a loose grasp on why this works, but I needed to make this change to get Surge to work both with Commander and Yargs.
