### PR TITLE
Adds basic tests for actions with Minimist, Yargs, Commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "minimist": "1.1.1"
   },
   "devDependencies": {
+    "commander": "2.9.0",
     "mocha": "*",
     "nixt": "0.4.1",
-    "should": "7.1.0"
+    "should": "7.1.0",
+    "yargs": "3.30.0"
   },
   "license": "ISC",
   "main": "./lib/surge.js",

--- a/test/actions.js
+++ b/test/actions.js
@@ -1,0 +1,51 @@
+var should = require('should')
+var minimist = require('minimist')(process.argv.slice(2))
+var yargs = require('yargs')
+var commander = require('commander')
+var Surge = require('../')
+var surge = new Surge
+var pkg = require('../package.json')
+var hooks = {}
+
+describe('actions', function (done) {
+
+  describe('login', function (done) {
+
+    it('action', function (done) {
+      should(surge.login(hooks)).type('function')
+      done()
+    })
+
+    it('commander', function (done) {
+      var program = commander
+      program
+        .command('login')
+        .action(surge.login(hooks))
+      should(program.commands.length).equal(1)
+      done()
+    })
+
+    it('minimist', function (done) {
+      var program = minimist
+      should(program._.length).equal(1)
+      done()
+    })
+
+    it('yargs', function (done) {
+      var program = yargs
+      program
+        .command('teardown', 'Login to Surge.', surge.login(hooks))
+        .argv
+      should(program.argv._.length).equal(1)
+      done()
+    })
+  })
+
+  // publish
+  // teardown
+  // whoami
+  // list
+  // plus
+  // logout
+
+})


### PR DESCRIPTION
Looking for feedback on this, these are some basic tests to make sure the `surge.login()` action works with Minimist, Yargs, and Commander. Not sure whether it’s better to test all of those specifically, since we try to have them work well together, or if we should just be test the actions exist?

![2](https://cloud.githubusercontent.com/assets/1581276/11283282/cc04a088-8eb8-11e5-9a60-31dee7e8d3cb.gif)

To try this out, run:

```sh
npm test -- test/actions.js
```

Only done for login so far. The tests could be more or less involved depending on what you think.