### PR TITLE
Should be able to specify whether you want to run the tests locally or not

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "main": "./lib/surge.js",
   "ignore": ["test"],
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test:local": "ENDPOINT='localhost:5001' ./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: false

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : ' '
 var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,7 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,
   newlines: false

--- a/test/cname.js
+++ b/test/cname.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: false

--- a/test/cname.js
+++ b/test/cname.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : ' '
 var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,

--- a/test/cname.js
+++ b/test/cname.js
@@ -2,7 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,
   newlines: false

--- a/test/plus.js
+++ b/test/plus.js
@@ -2,9 +2,9 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var ci = process.env.CI || false
-var endpoint = ci ? ' ' : ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: true
@@ -19,8 +19,8 @@ describe('plus', function () {
     this.timeout(25000)
 
     nixt(opts)
-      .exec(surge + 'logout' + endpoint) // Logout before the test starts
-      .run(surge + endpoint)
+      .exec(surge + 'logout') // Logout before the test starts
+      .run(surge)
       .on(/.*email:.*/).respond('kenneth+test@chloi.io\n')
       .on(/.*password:.*/).respond('12345\n')
       .on(/.*project path:.*/).respond('./test/fixtures/cli-test.surge.sh\n')
@@ -35,8 +35,7 @@ describe('plus', function () {
     this.timeout(50000)
 
     nixt(opts)
-      .run(surge + endpoint + 'plus')
-      .on(/.*domain:.*/).respond(subdomain + '\n')
+      .run(surge + 'plus ' + subdomain)
       .on(/.*Would you like to charge.*/).respond('yes\n')
       // .on(/.*card number:.*/).respond('4242-4242-4242-4242\n')
       // .on(/.*exp \(mo\/yr\):.*/).respond('01/19\n')
@@ -55,7 +54,7 @@ describe('plus', function () {
     this.timeout(50000)
 
     nixt(opts)
-      .run(surge + endpoint + 'ssl ' + subdomain)
+      .run(surge + 'ssl ' + subdomain)
       .on(/.*pem file:.*/).respond('./test/fixtures/ssl/test.pem\n')
       .on(/.*Would you like to charge.*/).respond('yes\n')
       .expect(function (result) {
@@ -95,7 +94,7 @@ describe('plus', function () {
     this.timeout(25000)
     
     nixt(opts)
-      .run(surge + 'teardown' + endpoint)
+      .run(surge + 'teardown')
       .on(/.*domain:.*/).respond(subdomain + '\n')
       .expect(function (result) {
         should(result.stdout).match(/Success/)

--- a/test/plus.js
+++ b/test/plus.js
@@ -4,7 +4,7 @@ var pkg = require('../package.json')
 
 var surge = 'node ' + pkg.bin + ' '
 var ci = process.env.CI || false
-var endpoint = ci ? '' : ' -e localhost:5001'
+var endpoint = ci ? ' ' : ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: true

--- a/test/plus.js
+++ b/test/plus.js
@@ -2,8 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
-var surge = 'node ' + pkg.bin + endpoint
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : false
+var surge = 'node ' + pkg.bin + (endpoint ? endpoint : ' ')
 var ci = process.env.CI || false
 var opts = {
   colors: false,
@@ -11,7 +11,7 @@ var opts = {
 }
 
 describe('plus', function () {
-  if (!ci) {
+  if (!ci && endpoint) {
 
   var subdomain = ''
 
@@ -92,7 +92,7 @@ describe('plus', function () {
 
   afterEach(function (done) {
     this.timeout(25000)
-    
+
     nixt(opts)
       .run(surge + 'teardown')
       .on(/.*domain:.*/).respond(subdomain + '\n')
@@ -104,6 +104,10 @@ describe('plus', function () {
   })
 
   } else {
-    console.warn('Plus tests aren’t yet configured to run on CI.')
+    if (ci) {
+      console.warn('Plus tests aren’t yet configured to run on CI.')
+    } else {
+      console.warn('Plus tests require a local endpoint specified.')
+    }
   }
 })

--- a/test/publish.js
+++ b/test/publish.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: false

--- a/test/publish.js
+++ b/test/publish.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : ' '
 var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,

--- a/test/publish.js
+++ b/test/publish.js
@@ -2,7 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,
   newlines: false

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: false

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : ' '
 var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -2,7 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,
   newlines: false

--- a/test/welcome.js
+++ b/test/welcome.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' '
+var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
 var opts = {
   colors: false,
   newlines: false

--- a/test/welcome.js
+++ b/test/welcome.js
@@ -2,7 +2,7 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var endpoint = typeof process.env.ENDPOINT !== 'undefined' ? ' -e ' + process.env.ENDPOINT + ' ' : ' '
 var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,

--- a/test/welcome.js
+++ b/test/welcome.js
@@ -2,7 +2,8 @@ var nixt = require('nixt')
 var should = require('should')
 var pkg = require('../package.json')
 
-var surge = 'node ' + pkg.bin + ' -e localhost:5001 '
+var endpoint = ' -e ' + process.env.ENDPOINT + ' ' || ''
+var surge = 'node ' + pkg.bin + endpoint
 var opts = {
   colors: false,
   newlines: false


### PR DESCRIPTION
~~__Don’t merge__~~

~~This PR hard-codes running the tests locally by including the endpoint. (This is basically what happens in `plus.js` if the `ci` environment variable isn’t defined.~~

~~It would be great to do something that let us run the tests against either endpoint. Either an environment variable, passing something into Mocha, whatever. I’m not sure what the best approach is, this is mostly a reminder / a way of doing it that works sort of.~~

To check all tests locally, run:

```
npm run test:local
```

All tests work as before: if you run `npm test` without an endpoint, the `surge plus` and `surge ssl` won’t run.