### PR TITLE
Adds a test for using surge as a subdomain

### DIFF
--- a/test/publish.js
+++ b/test/publish.js
@@ -127,6 +127,15 @@ describe('publish', function (done) {
       })
       .end(done)
   })
+  it('Should get a warning about publishing to a `surge.example.com` subdomain', function (done) {
+    this.timeout(25000)
+    nixt(opts)
+      .run(surge + './test/fixtures/cli-test.surge.sh surge.example.com')
+      .expect(function (result) {
+        should(result.stdout).match(/Aborted/)
+      })
+      .end(done)
+  })
 
   after(function (done) {
     this.timeout(25000)


### PR DESCRIPTION
This test is currently failing:

- [ ] Merge this PR
- [ ] Merge `ko-block-surge-subdomains` branch on Slushi if it looks good

Then it should be passing.

__Current__

![2](https://cloud.githubusercontent.com/assets/1581276/12101542/216b2632-b2ea-11e5-9654-5a833c1ab5e3.gif)

__Updated__

![5](https://cloud.githubusercontent.com/assets/1581276/12101543/216fb1a2-b2ea-11e5-8551-2deb18145128.gif)

There is a custom error message for the CLI, but those don’t seem to be getting passed along anymore.