### PR TITLE
Add "https://" to beginning of publish log so terminal emulators can detect it.

### DIFF
--- a/lib/middleware/ipaddress.js
+++ b/lib/middleware/ipaddress.js
@@ -5,7 +5,7 @@ module.exports = function(req, next){
   } else {
     console.log('         IP address:'.grey, "192.241.214.148")
     console.log()
-    console.log("    Success!".green + " Project is published and running at " + req.domain.green.underline)
+    console.log("    Success!".green + " Project is published and running at " + ("https://" + req.domain).green.underline)
     //console.log('             status:'.grey, req.status || "deployed")
     console.log("")
   }


### PR DESCRIPTION
Most terminal emulators need the protocol to tell it is a link and allow opening in browser.