### PR TITLE
Updates tar.gz to fix dependency on graceful-fs 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "split": "0.3.1",
     "surge-ignore": "0.2.0",
     "tar": "1.0.0",
-    "tar.gz": "0.1.1",
+    "tar.gz": "1.0.5",
     "url-parse-as-address": "1.0.0",
     "read": "1.0.5",
     "minimist": "1.1.1"


### PR DESCRIPTION
Keeping graceful-fs < 4 in Node 7+ is broken since it alters fs. Leading to issues such as nodejs/node#9377