### PR TITLE
fix(cli): token usage

### DIFF
--- a/lib/middleware/help.js
+++ b/lib/middleware/help.js
@@ -26,6 +26,7 @@ module.exports = function(req, next){
       .log("    surge login         only performs authentication step")
       .log("    surge list          list all domains you have access to")
       .log("    surge teardown      tear down a published project")
+      .log("    surge token         display authentication token")
       .log()
       .log("  Guides:".grey)
       .log("    Getting started     " + "surge.sh/help/getting-started-with-surge".underline.grey)

--- a/lib/surge.js
+++ b/lib/surge.js
@@ -93,7 +93,7 @@ module.exports = function(config){
     var postAuth    = hooks.postAuth      || stub
     var onion = [
       whitelist, endpoint, pkg, help, version, space,
-      preAuth, creds, welcome, tokencheck, email, auth, postAuth,
+      preAuth, creds, welcome, tokencheck, email, postAuth,
       token, space
     ]
     return function(){


### PR DESCRIPTION
# problem statements

- `token` isnt displayed in `surge -h`
- `token` is displayed twice on `surge token`

# solution

- show token in `-h` call
- drop `****` token from `surge token` call

## discussion

```
    Surge - surge.sh

              email: <user>
              token: *****************
              token:<mytoken>
```

to

```
    Surge - surge.sh

              email: <user>
              token: <mytoken>
```
may not be entirely obvious from dropping the `auth` call in the `token` cmd
