### PR TITLE
added workaround to avoid full upload

### DIFF
--- a/workarounds/avoid-full-upload.md
+++ b/workarounds/avoid-full-upload.md
@@ -1,0 +1,3 @@
+Host the files on IPFS, Surge.sh and GitLab. Then host the index on surge.
+
+When storing the files on surge.sh, I've no choice but occupy a surge subdomain for each files to avoid full upload. Maybe each surge.sh repo will contains  and


### PR DESCRIPTION
I would like to join the discussion at https://github.com/sintaxi/surge/issues/119 but the conversation has been locked and limited to collaborators. So I'm creating a PR instead.

This workaround may race sub-domain name among other users but the effect should be limited since naming conflict will only happen when hash collision occurs.

I still prefer to store files on surge.sh over IPFS since I cannot guarantee my node is online when the resource is being requested.

The advantage of using surge.sh over Github and GitLab is that I can choose to list or unlist the item according to the need. GitLab page seems to support private repo but I've not figured out how to even start the GitLab page.