### PR TITLE
Removing all domains added (teardownAll)

### DIFF
--- a/lib/middleware/confirmTeardownAll.js
+++ b/lib/middleware/confirmTeardownAll.js
@@ -1,0 +1,24 @@
+var helpers = require("./util/helpers.js");
+
+module.exports = function(req, next) {
+  helpers.trunc(
+    "\nAll the above domains will be removed. Do you want to continue? (y/n) \n"
+  );
+  helpers.read(
+    {
+      silent: false,
+      default: "",
+      edit: true,
+      output: req.argv._[0],
+      input: req.argv._[0]
+    },
+    function(err, option) {
+      if (["y", "yes"].includes(option.toLowerCase())) {
+        next();
+      } else {
+        helpers.trunc("Aborted".yellow + " - Unable to remove.".grey);
+        process.exit(1);
+      }
+    }
+  );
+};

--- a/lib/middleware/teardownAll.js
+++ b/lib/middleware/teardownAll.js
@@ -1,0 +1,62 @@
+var request = require("request");
+var url = require("url");
+var helpers = require("./util/helpers");
+var path = require("path");
+var parseUrl = require("url-parse-as-address");
+
+module.exports = function(req, next, abort) {
+  var options = {
+    url: url.resolve(req.endpoint.format(), "/list"),
+    method: "get",
+    auth: {
+      user: "token",
+      pass: req.creds.token,
+      sendImmediately: true
+    }
+  };
+
+  request(options, function(e, r, obj) {
+    if (e) throw e;
+    var list = JSON.parse(obj);
+    return list.map(item => {
+      remove(parseUrl(item.domain).host);
+    });
+  });
+
+  var remove = function(domain) {
+    var options = {
+      url: url.resolve(req.endpoint, domain),
+      method: "delete",
+      auth: {
+        user: "token",
+        pass: req.creds.token,
+        sendImmediately: true
+      }
+    };
+
+    request(options, function(e, r, obj) {
+      if (e) throw e;
+
+      if (r.statusCode == 200 || r.statusCode == 204 || r.statusCode == 210) {
+        helpers.space();
+        helpers.trunc(
+          "Success".green +
+            (" - " + domain.underline + " has been removed.").grey
+        );
+        helpers.space();
+      } else if (r.statusCode == 403) {
+        helpers.space();
+        helpers.trunc(
+          "Aborted".yellow +
+            (" - Unable to remove " + domain.underline + ".").grey
+        );
+        helpers.space();
+      } else {
+        helpers.space();
+        helpers.log(obj);
+        helpers.space();
+        process.exit();
+      }
+    });
+  };
+};

--- a/lib/surge.js
+++ b/lib/surge.js
@@ -33,6 +33,8 @@ var token       = require("./middleware/token")
 var teardown    = require("./middleware/teardown")
 var discovery   = require("./middleware/discovery")
 var plus        = require("./middleware/plus")
+var confirmTeardownAll       = require("./middleware/confirmTeardownAll")
+var teardownAll        = require("./middleware/teardownAll")
 
 var subscription= require("./middleware/subscription")
 var plans       = require("./middleware/plans")
@@ -60,9 +62,9 @@ var exitifcurrentplan = function(req, next){
 }
 
 
-var space = function(req, next){ 
+var space = function(req, next){
   helpers.space()
-  next() 
+  next()
 }
 
 var parse = function(arg){
@@ -112,7 +114,7 @@ module.exports = function(config){
     var argv = minimist(args, options)
     var cmd  = argv._[0]
 
-    var commands = ["login", "logout", "whoami", "list", "publish", "teardown", "token", "plus", "ssl", "plan", "card"]
+    var commands = ["login", "logout", "whoami", "list", "publish", "teardown", "token", "plus", "ssl", "plan", "card", "teardownAll"]
 
     if (commands.indexOf(cmd) !== -1) {
       argv._.shift()
@@ -344,6 +346,25 @@ module.exports = function(config){
       }, onion)
     }
   }
+
+  surge.teardownAll = function(hooks) {
+    var hooks = hooks || {};
+    var preAuth = hooks.preAuth || stub;
+    var postAuth = hooks.postAuth || stub;
+    var onion = [
+      whitelist, endpoint, pkg, help, version, space,
+      preAuth, creds, auth, postAuth,
+      shorthand, list, confirmTeardownAll, teardownAll, space
+    ]
+    return function() {
+      var argv = parse(arguments[arguments.length - 1]);
+      skin({
+        config: config,
+        argv: argv,
+        read: read
+      }, onion)
+    };
+  };
 
   return surge
 


### PR DESCRIPTION
Short description: Remove all the domain with a single command i.e. `surge teardownAll`

Long description: Thank you for surge. I had 8 domain running for last few months, which I wasn't using. So I wanted to remove all domains but deleting one by one is a painful task. So I added `surge teardown` to remove all the domain in a single go. 

Let me know if I can improve it.
