### PR TITLE
Surge v0.20.3 (latest) – Fixes issue with missing altnames from server

### DIFF
--- a/lib/middleware/deploy.js
+++ b/lib/middleware/deploy.js
@@ -155,7 +155,10 @@ module.exports = function(req, next){
       } else
       if (payload.hasOwnProperty("type") && payload.type === "cert") {
           //console.log(payload.data)
-          helpers.log(helpers.smart("encryption:").grey + " " + payload.data.altnames.join(", ") + ( " (" + payload.data.expiresInWords + ")").grey)
+          // Currently, some projects do have certs but don’t return this information
+          if (typeof payload.data.altnames !== 'undefined' && typeof payload.data.expiresInWords !== 'undefined') {
+            helpers.log(helpers.smart("encryption:").grey + " " + payload.data.altnames.join(", ") + ( " (" + payload.data.expiresInWords + ")").grey)
+          }
       } else
 
       if (payload.hasOwnProperty("type") && payload.type === "ip") {


### PR DESCRIPTION
It’s possible for `payload.data.altnames` to be `undefined` when publishing in Surge v0.20.3 and v0.20.2, so the publishing experience shows the following rather than a Successful deploy:

```
         upload: [====================] 100% eta: 0.0s (1 files, 11 bytes)
            CDN: [====================] 100%
…/lib/node_modules/surge/lib/middleware/deploy.js:158
          helpers.log(helpers.smart("encryption:").grey + " " + payload.data.altnames.join(", ") + ( " (" + payload.data.expiresInWords + ")").grey)
```

I’m not sure exactly what the circumstances are to get a project like this, but I am able to reproduce it with two projects with custom domains, one with and one without SSL certificates. It didn’t happen with a `*.surge.sh` project. My best guess is that this might happen if a parent project has SSL, but another project using a subdomain on that domain doesn’t?

The site was still published, but you never see “Success” in the CLI, and it causes the deployment to show as failed on CI systems.

This pull request fixes that issue from the CLI side of things at least. Surge v0.20.1 also works as expected. Thanks!
