### PR TITLE
Fix Undefined Project Values

### DIFF
--- a/lib/middleware/list.js
+++ b/lib/middleware/list.js
@@ -41,9 +41,9 @@ module.exports = function(req, next){
         }
         var row = [
           perm || project.domain,
-          project.timeAgoInWords.grey,
-          project.cmd.grey,
-          project.platform.grey,
+          (project.timeAgoInWords || "").grey,
+          (project.cmd || "").grey,
+          (project.platform || "").grey,
           pn || "",
           //lastcmd !== project.cmd ? (project.cmd).grey : "",
         ]


### PR DESCRIPTION
On some projects the API does not return values for `timeAgoInWords`, `cmd`, or `platform`.
This can lead to an occasional error `Cannot read property 'grey' of undefined` because of these missing values (as noted in #307).

This fix sets a fallback to empty string to avoid this error when listing projects"